### PR TITLE
 Add return type to getTests() method

### DIFF
--- a/Extension/InstanceOfExtension.php
+++ b/Extension/InstanceOfExtension.php
@@ -10,7 +10,7 @@ use Twig\TwigTest;
 
 class InstanceOfExtension extends AbstractExtension
 {
-    public function getTests()
+    public function getTests(): array
     {
         return [
             new TwigTest(


### PR DESCRIPTION
The return type was missing, causing 

Method "Twig\Extension\ExtensionInterface::getTests()" might add "array" as a native return type declaration in the future. Do the same in implementation "Lelyfoto\Twig\InstanceOf\Extension\InstanceOfExtension" now to avoid errors or add an explicit @return annotation to suppress this message.

messages in bin/console output