### PR TITLE
Add a return type to Fix deprecated message

### DIFF
--- a/DependencyInjection/TwigInstanceOfExtension.php
+++ b/DependencyInjection/TwigInstanceOfExtension.php
@@ -11,7 +11,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 
 class TwigInstanceOfExtension extends Extension
 {
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $loader = new PhpFileLoader($container, new FileLocator(\dirname(__DIR__) . '/Resources/config'));
         $loader->load('instanceof.php');


### PR DESCRIPTION


`Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "Lelyfoto\Twig\InstanceOf\DependencyInjection\TwigInstanceOfExtension" now to avoid errors or add an explicit @return annotation to suppress this message.`